### PR TITLE
Avoid scroll overlap with fixed footer

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,3 +1,7 @@
+main {
+    padding-bottom: 100px; /* height of footer + extra padding */
+}
+
 .main {
     margin: 0;
 }
@@ -44,4 +48,3 @@ footer {
 .flink {
     padding-right: 10px;
 }
-

--- a/app/footer.php
+++ b/app/footer.php
@@ -1,3 +1,4 @@
+</main>
 <footer id="footer">
     <small> 
     This work is licensed under <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img title="CC BY-NC-SA 4.0 International License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png" alt="CC BY-NC-SA 4.0 International License"></a>

--- a/app/header.php
+++ b/app/header.php
@@ -4,3 +4,4 @@
     <h1><a href="/" style="color:inherit">Code of Conduct Builder</a></h1>
 </div>
 
+<main>


### PR DESCRIPTION
Added a main wrapper around primary page content, that has some bottom padding. This will fix the issue with bottom of the page content getting stuck under the footer on low window heights.

Resolves #26. 