### PR TITLE
adding twitter profile link

### DIFF
--- a/app/header.php
+++ b/app/header.php
@@ -1,4 +1,5 @@
-<span class="banner"> This website is still in development (pre-beta) at the moment. Please send feedback to <a href="mailto:alex0morley@gmail.com?Subject=Code%20of%20Conducts">alex0morley@gmail.com</a> or @alexmorley on twitter. Thanks!</span>
+<span class="banner"> This website is still in development (pre-beta) at the moment. Please send feedback to <a href="mailto:alex0morley@gmail.com?Subject=Code%20of%20Conducts">alex0morley@gmail.com</a> or <a href="https://twitter.com/alexmorley">@alexmorley</a> on twitter. Thanks!</span>
+
 
 <div id="title" class="container"> 
     <a href="/" style="color:inherit"><img src="assets/images/logo_wide.png" alt="Code of Conduct Builder Logo" style="height: 8%; margin-left:auto; margin-right:auto; display: block"></a>


### PR DESCRIPTION
- Adding Twitter profile link in `header`

## Code snippet:
`... or <a href="https://twitter.com/alexmorley">@alexmorley</a> on twitter. Thanks!</span>`

- I think this will be helpful for a visitor to directly going to profile instead of typing and searching

## Issue solved:
Adding Twitter profile link in header #52